### PR TITLE
Fix escapes in PS1 string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,6 @@ class bash_prompt
   file_line { 'show-deployment-in-root-prompt':
     ensure => 'present',
     path   => $bashrc_file,
-    line   => "export PS1=\"(${prompt_string}) \u@\h:\w\$ \"",
+    line   => "export PS1=\"(${prompt_string}) \\u@\\h:\\w\\$ \"",
   }
 }


### PR DESCRIPTION
Removes the following warnings:
Unicode escape '\u' was not followed by 4 hex digits or
1-6 hex digits in {} or was > 10ffff (file: bash_prompt/manifests/init.pp, line: 50, column: 62)
Unrecognized escape sequence '\h'
(file: bash_prompt/manifests/init.pp, line: 50, column: 62)
Unrecognized escape sequence '\w'
(file: bash_prompt/manifests/init.pp, line: 50, column: 62)

Also fixes PS1 to specify \$ instead of $ (although that doesn't
seem to actually break anything).

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>
